### PR TITLE
DF-2071 - Add Get Document Endpoint

### DIFF
--- a/digitalforms-api-specification/src/main/resources/VI_IRP_V1.yaml
+++ b/digitalforms-api-specification/src/main/resources/VI_IRP_V1.yaml
@@ -187,33 +187,21 @@ paths:
         schema:
           type: integer
           format: int64
-      - name: b64
-        in: query
-        description: Boolean. Base64 response 
-        schema:
-          type: boolean
-          default: false
-      - name: url
-        in: query
-        description: Boolean. Indicates url reference response only 
-        schema:
-          type: boolean
-          default: false
       responses:
         200:
           description: Success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/vipsDocumentResponse'
+                $ref: '#/components/schemas/vipsGetDocumentByIdResponse'
+        500:
+          $ref: '#/components/responses/500ServerError'
         400:
-          $ref: '#/components/responses/400BadRequest'        
+          $ref: '#/components/responses/400BadRequest'
         401:
           $ref: '#/components/responses/401NotAuthorized'
-        403:
-          $ref: '#/components/responses/403Forbidden'
         404:
-          $ref: '#/components/responses/404NotFound'  
+          $ref: '#/components/responses/404NotFound'
   /documents/list/{noticeNo}/{correlationId}:
     get:
       security:
@@ -1062,7 +1050,13 @@ components:
       properties:
         document_id:
           type: string
-          description: Doc id to be attached to impoundment or prohibition. 
+          description: Doc id to be attached to impoundment or prohibition.
+    vipsGetDocumentByIdResponse:
+      type: object
+      properties:
+        document:
+          type: string
+          description: The Document returned as a base64 string for the given documentId.
     errorMessage:
       type: object
       required:

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DocumentsApiDelegateImpl.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DocumentsApiDelegateImpl.java
@@ -2,6 +2,7 @@ package ca.bc.gov.open.digitalformsapi.viirp.controller;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -11,12 +12,17 @@ import ca.bc.gov.open.digitalformsapi.viirp.model.AssociateDocumentToNoticeServi
 import ca.bc.gov.open.digitalformsapi.viirp.model.GetDocumentsListServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.StoreVIPSDocument;
 import ca.bc.gov.open.digitalformsapi.viirp.model.VipsDocumentResponse;
+import ca.bc.gov.open.digitalformsapi.viirp.model.VipsGetDocumentByIdResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.VipsNoticeObj;
+import ca.bc.gov.open.digitalformsapi.viirp.service.VipsRestService;
 
 @Service
 public class DocumentsApiDelegateImpl implements DocumentsApiDelegate{
 	
 	private final Logger logger = LoggerFactory.getLogger(DocumentsApiDelegateImpl.class);
+	
+	@Autowired
+	private VipsRestService digitalformsApiService;
 	
 	@Override
 	public ResponseEntity<GetDocumentsListServiceResponse> documentsListNoticeNoCorrelationIdGet(String noticeNo,
@@ -49,15 +55,15 @@ public class DocumentsApiDelegateImpl implements DocumentsApiDelegate{
 	}
 	
 	@Override
-	public ResponseEntity<VipsDocumentResponse> documentsDocumentIdCorrelationIdGet(
+	public ResponseEntity<VipsGetDocumentByIdResponse> documentsDocumentIdCorrelationIdGet(
 			String correlationId,
-	        Long documentId,
-	        Boolean b64,
-	        Boolean url) {
+	        Long documentId) {
 		
-		logger.info("Heard a call to the endpoint 'documentsDocumentIdCorrelationIdGet' with documentId " + documentId + ", b64 " + b64 + ", url " + url);
+		logger.info("Heard a call to the endpoint 'documentsDocumentIdCorrelationIdGet' with documentId " + documentId);
 		
-		return new ResponseEntity<>(HttpStatus.OK);
+		VipsGetDocumentByIdResponse documentResponse = digitalformsApiService.getDocumentAsBase64(correlationId, documentId);
+		
+		return new ResponseEntity<>(documentResponse, HttpStatus.OK);
 	}
 
 }

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestService.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestService.java
@@ -1,6 +1,7 @@
 package ca.bc.gov.open.digitalformsapi.viirp.service;
 
 import ca.bc.gov.open.digitalformsapi.viirp.model.GetCodetablesServiceResponse;
+import ca.bc.gov.open.digitalformsapi.viirp.model.VipsGetDocumentByIdResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.GetImpoundmentServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.SearchImpoundmentsServiceResponse;
 
@@ -54,5 +55,15 @@ public interface VipsRestService {
 	 * @return
 	 */
 	public GetImpoundmentServiceResponse getImpoundment(String correlationId, Long impoundmentId);
+	
+	/**
+	 * 
+	 * Returns a {@link VipsGetDocumentByIdResponse} by calling VIPS WS to return a document Base64 for a given document Id.
+	 * 
+	 * @param correlationId
+	 * @param documentId
+	 * @return
+	 */
+	public VipsGetDocumentByIdResponse getDocumentAsBase64(String correlationId, Long documentId);
 	
 }

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestServiceImpl.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import ca.bc.gov.open.digitalformsapi.viirp.config.ConfigProperties;
 import ca.bc.gov.open.digitalformsapi.viirp.model.GetCodetablesServiceResponse;
+import ca.bc.gov.open.digitalformsapi.viirp.model.VipsGetDocumentByIdResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.GetImpoundmentServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.SearchImpoundmentsServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.utils.DigitalFormsConstants;
@@ -102,6 +103,33 @@ public class VipsRestServiceImpl implements VipsRestService {
         		.header(DigitalFormsConstants.VIPS_API_HEADER_USER, properties.getVipsRestApiCredentialsUser())
                 .retrieve()
                 .bodyToMono(GetImpoundmentServiceResponse.class) // body of response (VIPS WS class)
+        		.block();
+	}
+	
+	/**	  
+	 * getDocument. 
+	 * 
+	 * VIPS WS response object returned for given document Id. 
+ 	 * 
+	 */
+	@Override
+	public VipsGetDocumentByIdResponse getDocumentAsBase64(String correlationId, Long documentId) {
+		
+		return webClient
+                .get()
+                .uri("/documents/" + documentId + "?b64=true&url=false")
+                .headers (headers -> headers.setBasicAuth(properties.getVipsRestApiUsername(), properties.getVipsRestApiPassword()) )
+        		.header(DigitalFormsConstants.VIPS_API_HEADER_GUID, properties.getVipsRestApiCredentialsGuid()) 
+        		.header(DigitalFormsConstants.VIPS_API_HEADER_DISPLAYNAME, properties.getVipsRestApiCredentialsDisplayname())
+        		.header(DigitalFormsConstants.VIPS_API_HEADER_USER, properties.getVipsRestApiCredentialsUser())
+                .retrieve()
+                .bodyToMono(String.class) // Get the base64 encoded string from the response
+                .map(base64String -> {
+                	// Add base64 string to the response object
+                    VipsGetDocumentByIdResponse response = new VipsGetDocumentByIdResponse();
+                    response.setDocument(base64String);
+                    return response;
+                })
         		.block();
 	}
 	


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- DF-2071
- Added functionality to return a document as base64 encoded string for a given documentId by calling VIPS API through the new documentsDocumentIdCorrelationIdGet endpoint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Build and ran the 'digitalforms-api' application. Ran Swagger-UI. Sent a request to the GET '/documents' endpoint of the API with valid documentId parameter and confirmed returning base64 encoded string response object successfully.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes