### PR TITLE
DF-2071 add error handling and unit tests

### DIFF
--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/utils/DigitalFormsConstants.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/utils/DigitalFormsConstants.java
@@ -42,6 +42,7 @@ public final class DigitalFormsConstants {
 	public static final String UNIT_TEST_CORRELATION_ID = "1234567";
 	public static final String UNIT_TEST_NOTICE_NUMBER = "22222222";
 	public static final Long UNIT_TEST_IMPOUNDMENT_ID = 1234L;
+	public static final Long UNIT_TEST_DOCUMENT_ID = 1234L;
 	
 	
 	

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestServiceTest.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import java.util.Base64;
 import java.util.function.Consumer;
 
 import org.junit.After;
@@ -20,6 +21,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import ca.bc.gov.open.digitalformsapi.viirp.model.GetCodetablesServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.VipsConfigurationObj;
+import ca.bc.gov.open.digitalformsapi.viirp.model.VipsGetDocumentByIdResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.utils.DigitalFormsConstants;
 import reactor.core.publisher.Mono;
 
@@ -74,5 +76,36 @@ public class VipsRestServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.getRespMsg()).isEqualTo("Success");
         assertThat(result.getConfiguration()).usingRecursiveComparison().isEqualTo(configuration);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+    public void getDocumentAsBase64() {
+		
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+    	Long documentId = DigitalFormsConstants.UNIT_TEST_DOCUMENT_ID;
+		
+    	VipsGetDocumentByIdResponse vipsDocumentResponse = new VipsGetDocumentByIdResponse();
+		
+    	Base64.Encoder enc = Base64.getEncoder();
+		String testStr = "77+9x6s=";
+		// encode data using BASE64
+		String encodedBase64 = enc.encodeToString(testStr.getBytes());
+		vipsDocumentResponse.setDocument(encodedBase64);
+		
+		when(this.webClient.get()).thenReturn(this.requestHeadersUriMock);
+        when(this.requestHeadersUriMock.uri("/documents/" + documentId + "?b64=true&url=false")).thenReturn(this.requestHeadersMock);
+        when(this.requestHeadersMock.headers(any(Consumer.class))).thenReturn(this.requestHeadersMock);
+        when(this.requestHeadersMock.header(any(String.class), any(String.class))).thenReturn(this.requestHeadersMock);
+        when(this.requestHeadersMock.header(any(String.class), any(String.class))).thenReturn(this.requestHeadersMock);
+        when(this.requestHeadersMock.header(any(String.class), any(String.class))).thenReturn(this.requestHeadersMock);
+        when(this.requestHeadersMock.retrieve()).thenReturn(this.responseMock);
+        when(this.responseMock.bodyToMono(String.class)).thenReturn(Mono.just(encodedBase64));
+        
+        var result = service.getDocumentAsBase64(correlationId, documentId);
+        
+        assertThat(result).isNotNull();
+        assertThat(result.getDocument()).isEqualTo(encodedBase64);
+        assertThat(result).usingRecursiveComparison().isEqualTo(vipsDocumentResponse);
 	}
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added proper error handling for the get document endpoint if the request fails to respond with proper base64 document string. 
- Also added unit tests for controller and service to cover some potential responses that the endpoint may return and validate if they are handled properly.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes