### PR TITLE
DF-2072 - Add Get Documents List

### DIFF
--- a/digitalforms-api-specification/src/main/resources/VI_IRP_V1.yaml
+++ b/digitalforms-api-specification/src/main/resources/VI_IRP_V1.yaml
@@ -233,10 +233,10 @@ paths:
                 $ref: '#/components/schemas/GetDocumentsListServiceResponse'
         401:
           $ref: '#/components/responses/401NotAuthorized'
-        403:
-          $ref: '#/components/responses/403Forbidden'
         404:
           $ref: '#/components/responses/404NotFound'
+        500:
+          $ref: '#/components/responses/500ServerError'
   /documents/association/notice/{documentId}/{correlationId}:
     post:
       tags:

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/model/vips/GetDocumentsListServiceResponse.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/model/vips/GetDocumentsListServiceResponse.java
@@ -1,0 +1,34 @@
+package ca.bc.gov.open.digitalformsapi.viirp.model.vips;
+
+import java.util.List;
+
+import ca.bc.gov.open.digitalformsapi.viirp.model.VipsDocumentObj;
+
+/**
+ * 
+ * GetDocumentsListServiceResponse - used to hold response from VIPS Get Documents Meta List
+ * 
+ * @author 237563
+ *
+ */
+public final class GetDocumentsListServiceResponse extends VipswsBasicResponse {
+
+	private List<VipsDocumentObj> results = null;
+    
+    public GetDocumentsListServiceResponse(){};
+
+    public GetDocumentsListServiceResponse(int respCd, String respMsg, List<VipsDocumentObj> results){
+        this.respCd = respCd;
+        this.respMsg = respMsg;
+        this.setResult(results);
+    }
+
+	public List<VipsDocumentObj> getResults() {
+		return results;
+	}
+
+	public void setResult(List<VipsDocumentObj> results) {
+		this.results = results;
+	}
+
+}

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestService.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestService.java
@@ -4,6 +4,7 @@ import ca.bc.gov.open.digitalformsapi.viirp.model.GetCodetablesServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.VipsGetDocumentByIdResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.VipsNoticeObj;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.AssociateDocumentToNoticeServiceResponse;
+import ca.bc.gov.open.digitalformsapi.viirp.model.vips.GetDocumentsListServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.GetImpoundmentServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.GetProhibitionServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.SearchImpoundmentsServiceResponse;
@@ -95,6 +96,17 @@ public interface VipsRestService {
 	 * @return
 	 */
 	public VipsGetDocumentByIdResponse getDocumentAsBase64(String correlationId, Long documentId);
+	
+	/**
+	 * 
+	 * Returns a {@link GetDocumentsListServiceResponse} by calling VIPS WS to retrieve documents associated with a given Impoundment or Prohibition Id.
+	 * 
+	 * @param correlationId
+	 * @param impoundmentId
+	 * @param prohibitionId
+	 * @return
+	 */
+	public GetDocumentsListServiceResponse getDocumentsMetaList(String correlationId, Long impoundmentId, Long prohibitionId);
 
 	
 	/**

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestServiceImpl.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestServiceImpl.java
@@ -10,6 +10,7 @@ import ca.bc.gov.open.digitalformsapi.viirp.model.VipsGetDocumentByIdResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.VipsNoticeObj;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.AssociateDocumentToNoticeServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.CreateProhibitionServiceResponse;
+import ca.bc.gov.open.digitalformsapi.viirp.model.vips.GetDocumentsListServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.GetImpoundmentServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.GetProhibitionServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.vips.SearchImpoundmentsServiceResponse;
@@ -228,6 +229,36 @@ public class VipsRestServiceImpl implements VipsRestService {
                 .body(Mono.just(prohibition), ca.bc.gov.open.digitalformsapi.viirp.model.CreateImpoundment.class) // body of request.
                 .retrieve()
                 .bodyToMono(ca.bc.gov.open.digitalformsapi.viirp.model.vips.CreateProhibitionServiceResponse.class) // body of response (need VIPS class)
+        		.block();
+	}
+
+	/**
+	 * 
+	 * getDocumentsMetaList.
+	 * VIPS WS response object returned given impoundment or prohibition Id. 
+	 *
+	 */
+	@Override
+	public GetDocumentsListServiceResponse getDocumentsMetaList(String correlationId, Long impoundmentId,
+			Long prohibitionId) {
+		
+		String documentsUri = "/documents?";
+		
+		if (impoundmentId != null) {
+			documentsUri = documentsUri + "impoundmentId=" + impoundmentId;
+		} else {
+			documentsUri = documentsUri + "prohibitionId=" + prohibitionId;
+		}
+		
+		return webClient
+                .get()
+                .uri(documentsUri)
+                .headers (headers -> headers.setBasicAuth(properties.getVipsRestApiUsername(), properties.getVipsRestApiPassword()) )
+        		.header(DigitalFormsConstants.VIPS_API_HEADER_GUID, properties.getVipsRestApiCredentialsGuid()) 
+        		.header(DigitalFormsConstants.VIPS_API_HEADER_DISPLAYNAME, properties.getVipsRestApiCredentialsDisplayname())
+        		.header(DigitalFormsConstants.VIPS_API_HEADER_USER, properties.getVipsRestApiCredentialsUser())
+                .retrieve()
+                .bodyToMono(GetDocumentsListServiceResponse.class)
         		.block();
 	}
 	


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [DF-2072](https://justice.gov.bc.ca/jirarsi/browse/DF-2072)
- Added functionality to perform an impoundment search and a prohibition search based on the notice ID given in order to retrieve a list of documents meta data from the GET /documents VIPS endpoint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran the API locally and sent a proper payload including a notice id for both impoundment and prohibition ids to retrieve documents meta data list and confirmed that the API returns the required data without any issues.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes