### PR TITLE
DF-2209-Add basic authentication

### DIFF
--- a/digitalforms-api/pom.xml
+++ b/digitalforms-api/pom.xml
@@ -44,6 +44,12 @@
 		</dependency>
 		
 		<dependency>
+    		<groupId>org.springframework.security</groupId>
+    		<artifactId>spring-security-test</artifactId>
+    		<scope>test</scope>
+		</dependency>
+		
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>

--- a/digitalforms-api/pom.xml
+++ b/digitalforms-api/pom.xml
@@ -40,6 +40,11 @@
 		
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/config/ConfigProperties.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/config/ConfigProperties.java
@@ -41,6 +41,11 @@ public class ConfigProperties {
     @Value("${vips.rest-api.credentials.displayname}")
     private String vipsRestApiCredentialsDisplayname;
     
+    @Value("${digitalforms.basic-auth.user}")
+    private String digitalFormsBasicAuthUser;
+
+	@Value("${digitalforms.basic-auth.password}")
+	private String digitalFormsBasicAuthPassword;
 
 	public String getVipsRestApiUrl() {
 		return vipsRestApiUrl;
@@ -112,6 +117,22 @@ public class ConfigProperties {
 
 	public void setVipsRestApiCredentialsDisplayname(String vipsRestApiCredentialsDisplayname) {
 		this.vipsRestApiCredentialsDisplayname = vipsRestApiCredentialsDisplayname;
+	}
+	
+    public String getDigitalFormsBasicAuthUser() {
+		return digitalFormsBasicAuthUser;
+	}
+
+	public void setDigitalFormsBasicAuthUser(String digitalFormsBasicAuthUser) {
+		this.digitalFormsBasicAuthUser = digitalFormsBasicAuthUser;
+	}
+
+	public String getDigitalFormsBasicAuthPassword() {
+		return digitalFormsBasicAuthPassword;
+	}
+
+	public void setDigitalFormsBasicAuthPassword(String digitalFormsBasicAuthPassword) {
+		this.digitalFormsBasicAuthPassword = digitalFormsBasicAuthPassword;
 	}
     
 }

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/config/SwaggerConfig.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/config/SwaggerConfig.java
@@ -3,18 +3,34 @@ package ca.bc.gov.open.digitalformsapi.viirp.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 
 @Configuration
 public class SwaggerConfig {
+	
+	private static final String SCHEME_NAME = "basicAuth";
+    private static final String SCHEME = "basic";
 	
 	@Bean
 	public OpenAPI vipsIntegrationOpenAPI() {
 		return new OpenAPI().info(new Info()
 		          .title("VIPS Integration API")
 		          .description("VIPS Integration API")
-		          .version("v1.0.2"));
+		          .version("v1.0.2"))
+				  .components(new Components()
+						  .addSecuritySchemes(SCHEME_NAME, createSecurityScheme()))
+				  .addSecurityItem(new SecurityRequirement().addList(SCHEME_NAME));
 	}
+	
+	private SecurityScheme createSecurityScheme() {
+        return new SecurityScheme()
+                .name(SCHEME_NAME)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme(SCHEME);
+    }
 
 }

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/exception/DigitalFormsAuthenticationFailureHandler.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/exception/DigitalFormsAuthenticationFailureHandler.java
@@ -31,7 +31,7 @@ public class DigitalFormsAuthenticationFailureHandler extends BasicAuthenticatio
 		
 		String errorMessage = "401 - Unauthorized entry, please authenticate";
 		JSONObject json = new JSONObject();
-		json.put("unauthorized-error", errorMessage);
+		json.put("status_message", errorMessage);
 		
 		logger.debug("API basic authentication failed");
 		response.setContentType(DigitalFormsConstants.JSON_CONTENT);

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/exception/DigitalFormsAuthenticationFailureHandler.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/exception/DigitalFormsAuthenticationFailureHandler.java
@@ -1,0 +1,49 @@
+package ca.bc.gov.open.digitalformsapi.viirp.exception;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import ca.bc.gov.open.digitalformsapi.viirp.utils.DigitalFormsConstants;
+
+/**
+ * Authentication failure response handler
+ * 
+ * @author 237563
+ *
+ */
+@Component
+public class DigitalFormsAuthenticationFailureHandler extends BasicAuthenticationEntryPoint  {
+	
+	private final Logger logger = LoggerFactory.getLogger(DigitalFormsAuthenticationFailureHandler.class);
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException authException) throws IOException {
+		
+		String errorMessage = "401 - Unauthorized entry, please authenticate";
+		JSONObject json = new JSONObject();
+		json.put("unauthorized-error", errorMessage);
+		
+		logger.debug("API basic authentication failed");
+		response.setContentType(DigitalFormsConstants.JSON_CONTENT);
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setCharacterEncoding("UTF-8");
+		response.getOutputStream().print(json.toString());
+	}
+	
+	@Override
+    public void afterPropertiesSet() {
+        setRealmName("DigitalForms - VI IRP API");
+        super.afterPropertiesSet();
+    }
+
+}

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/security/ApiSecurityConfig.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/security/ApiSecurityConfig.java
@@ -1,0 +1,84 @@
+package ca.bc.gov.open.digitalformsapi.viirp.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import ca.bc.gov.open.digitalformsapi.viirp.config.ConfigProperties;
+import ca.bc.gov.open.digitalformsapi.viirp.exception.DigitalFormsAuthenticationFailureHandler;
+
+/**
+ * 
+ * This class enforces Basic Auth on all API operations.  
+ * 
+ * It is assumed all Actuator calls are prefixed with /actuator/*  (No security)
+ * 
+ * Excludes all Swagger UI related endpoints (No security)
+ * 
+ * @author 237563
+ *
+ */
+@Configuration
+@EnableWebSecurity
+public class ApiSecurityConfig {
+	
+	private static final String[] AUTH_WHITELIST = {
+
+            // Non protected Swagger UI and Actuator endpoints.
+			"/swagger-ui/**",
+            "/swagger-resources/**",
+            "/swagger-ui/index.html",
+            "/swagger-ui.html",
+            "/v3/api-docs/**",
+            "/actuator/**"
+    };
+	
+	@Autowired
+	private ConfigProperties properties;
+	
+	@Autowired
+	private DigitalFormsAuthenticationFailureHandler authenticationFailureHandler;
+	
+	@Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		
+		// Stateless session validates basic auth credentials for each request
+		http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+		http.csrf().disable().authorizeRequests()
+			.antMatchers(AUTH_WHITELIST).permitAll()
+			.anyRequest().authenticated()
+			.and()
+			.httpBasic();
+		
+		// Authentication failure error response handler
+		http.exceptionHandling().authenticationEntryPoint(authenticationFailureHandler);
+		
+		return http.build();
+	}
+	
+	@Bean
+    public InMemoryUserDetailsManager userDetailsService() {
+        UserDetails user = User.builder()
+            .username(properties.getDigitalFormsBasicAuthUser())
+            .password(passwordEncoder().encode(properties.getDigitalFormsBasicAuthPassword()))
+            .roles("USER")
+            .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+	
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+	
+}

--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/utils/DigitalFormsConstants.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/utils/DigitalFormsConstants.java
@@ -47,6 +47,7 @@ public final class DigitalFormsConstants {
 	public static final Long UNIT_TEST_PROHIBITION_ID = 1234L;
 	public static final Long UNIT_TEST_DOCUMENT_ID = 1234L;
 	
-	
+	// rest response media type
+	public static final String JSON_CONTENT = "application/json";
 	
 }

--- a/digitalforms-api/src/main/resources/application.yml
+++ b/digitalforms-api/src/main/resources/application.yml
@@ -50,4 +50,6 @@ digitalforms:
     basePath: ${DIGITALFORMS_ORDS_BASEPATH}
     password: ${DIGITALFORMS_ORDS_PASSWORD}
     username: ${DIGITALFORMS_ORDS_USER}
-   
+  basic-auth:
+    user: ${DIGITALFORMS_BASICAUTH_USER}
+    password: ${DIGITALFORMS_BASICAUTH_PASSWORD}

--- a/digitalforms-api/src/main/resources/application.yml
+++ b/digitalforms-api/src/main/resources/application.yml
@@ -50,6 +50,7 @@ digitalforms:
     basePath: ${DIGITALFORMS_ORDS_BASEPATH}
     password: ${DIGITALFORMS_ORDS_PASSWORD}
     username: ${DIGITALFORMS_ORDS_USER}
+    
   basic-auth:
-    user: ${DIGITALFORMS_BASICAUTH_USER}
-    password: ${DIGITALFORMS_BASICAUTH_PASSWORD}
+    user: ${DIGITALFORMS_BASICAUTH_USER:}
+    password: ${DIGITALFORMS_BASICAUTH_PASSWORD:}

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/DigitalformsApiApplicationTests.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/DigitalformsApiApplicationTests.java
@@ -2,8 +2,10 @@ package ca.bc.gov.open.digitalformsapi.viirp;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles(value = "test")
 class DigitalformsApiApplicationTests {
 
 	@Test

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/CodeTablesApiControllerTests.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/CodeTablesApiControllerTests.java
@@ -20,6 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import ca.bc.gov.open.digitalformsapi.viirp.config.ConfigProperties;
@@ -29,7 +30,8 @@ import ca.bc.gov.open.digitalformsapi.viirp.service.VipsRestService;
 import ca.bc.gov.open.digitalformsapi.viirp.utils.DigitalFormsConstants;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
+@ActiveProfiles(value = "test")
+@AutoConfigureMockMvc(addFilters = false)
 @RunWith(MockitoJUnitRunner.class)
 @ExtendWith(MockitoExtension.class)
 class CodeTablesApiControllerTests {

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DocumentsApiControllerTests.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DocumentsApiControllerTests.java
@@ -22,6 +22,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -45,7 +46,8 @@ import ca.bc.gov.open.jag.ordsvipsclient.api.handler.ApiException;
 import ca.bc.gov.open.jag.ordsvipsclient.api.model.VipsDocumentOrdsResponse;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
+@ActiveProfiles(value = "test")
+@AutoConfigureMockMvc(addFilters = false)
 public class DocumentsApiControllerTests {
 
 	@Autowired

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/ImpoundmentsApiControllerTests.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/ImpoundmentsApiControllerTests.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -40,7 +41,8 @@ import ca.bc.gov.open.digitalformsapi.viirp.service.VipsRestService;
 import ca.bc.gov.open.digitalformsapi.viirp.utils.DigitalFormsConstants;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
+@ActiveProfiles(value = "test")
+@AutoConfigureMockMvc(addFilters = false)
 public class ImpoundmentsApiControllerTests {
 	
 	@Autowired

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/ProhibitionsApiControllerTests.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/ProhibitionsApiControllerTests.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
@@ -37,7 +38,8 @@ import ca.bc.gov.open.digitalformsapi.viirp.service.VipsRestService;
 import ca.bc.gov.open.digitalformsapi.viirp.utils.DigitalFormsConstants;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
+@ActiveProfiles(value = "test")
+@AutoConfigureMockMvc(addFilters = false)
 public class ProhibitionsApiControllerTests {
 	
 	@Autowired

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/exception/ControllerExceptionHandlerTests.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/exception/ControllerExceptionHandlerTests.java
@@ -9,12 +9,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import ca.bc.gov.open.digitalformsapi.viirp.utils.DigitalFormsConstants;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@AutoConfigureMockMvc
+@ActiveProfiles(value = "test")
+@AutoConfigureMockMvc(addFilters = false)
 class ControllerExceptionHandlerTests {
 	
 	@Autowired

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestServiceTest.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/service/VipsRestServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -27,6 +28,7 @@ import reactor.core.publisher.Mono;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
+@ActiveProfiles(value = "test")
 public class VipsRestServiceTest {
 	
 	@MockBean 

--- a/digitalforms-api/src/test/resources/application-test.yml
+++ b/digitalforms-api/src/test/resources/application-test.yml
@@ -1,0 +1,10 @@
+# Digital Forms API Application test properties. 
+server:
+  port: 8082
+  servlet:
+    context-path: /digitalforms-viirp/v1
+    
+digitalforms:
+  basic-auth:
+    password: password
+    user: user


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [DF-2209](https://justice.gov.bc.ca/jirarsi/browse/DF-2209)
- Added basic authentication to all VI IRP API operations as well as authentication on Swagger UI using Spring web security framework.
- In order to set the basic authentication credentials, the following env variables need to be set for the run configurations:
DIGITALFORMS_BASICAUTH_PASSWORD
DIGITALFORMS_BASICAUTH_USER

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?
Ran the app locally and sent requests to the endpoints via Swagger UI in both authenticated and unauthenticated state. 

Please describe the tests that you ran to verify your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes