### PR TITLE
DF-2208 Upgraded maven dependency libraries

### DIFF
--- a/digitalforms-api-specification/pom.xml
+++ b/digitalforms-api-specification/pom.xml
@@ -13,17 +13,16 @@
 
         <swagger-annotations-version>1.6.6</swagger-annotations-version>
         <springdoc-openapi-ui-version>1.6.9</springdoc-openapi-ui-version>
-        <jersey-version>2.27</jersey-version>
-        <jackson-version>2.10.2</jackson-version>
-        <jodatime-version>2.7</jodatime-version>
+        <jersey-version>3.1.0-M8</jersey-version>
+        <jackson-version>2.13.4</jackson-version>
+        <jodatime-version>2.11.1</jodatime-version>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <junit-version>4.8.1</junit-version>
-        <threetenbp-version>1.3.8</threetenbp-version>
-        <datatype-threetenbp-version>2.6.4</datatype-threetenbp-version>
-        <spring-boot-version>2.7.1</spring-boot-version>
-        <junit-version>4.12</junit-version>
+        <datatype-threetenbp-version>2.12.5</datatype-threetenbp-version>
+        <spring-boot-version>2.7.3</spring-boot-version>
+        <junit-version>4.13.2</junit-version>
         <migbase64-version>2.2</migbase64-version>
-        <jackson-databind-nullable>0.2.1</jackson-databind-nullable>
+        <jackson-databind-nullable>0.2.3</jackson-databind-nullable>
+        <javax-annotation-version>1.3.2</javax-annotation-version>
     </properties>
 
     <dependencies>
@@ -124,6 +123,11 @@
             <artifactId>jackson-databind-nullable</artifactId>
             <version>${jackson-databind-nullable}</version>
         </dependency>
+        <dependency>
+		  	<groupId>javax.annotation</groupId>
+		  	<artifactId>javax.annotation-api</artifactId>
+		  	<version>${javax-annotation-version}</version>
+		</dependency>
     </dependencies>
 
     <build>
@@ -131,7 +135,7 @@
             <plugin>
                 <groupId>org.openapitools</groupId>
                 <artifactId>openapi-generator-maven-plugin</artifactId>
-                <version>6.0.0</version>
+                <version>6.1.0</version>
                 <executions>
                     <execution>
                         <goals>
@@ -155,7 +159,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>11</source>
                     <target>11</target>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [DF-2208](https://justice.gov.bc.ca/jirarsi/browse/DF-2208)
- Upgraded all maven dependencies in specification module to attempt to fix Trivy scan vulnerability issues due to the outdated dependency libraries.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes