### PR TITLE
DF-2224 Added functionality to DELETE Digital Forms Payload

### DIFF
--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DfPayloadsApiDelegateImpl.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DfPayloadsApiDelegateImpl.java
@@ -116,23 +116,16 @@ public class DfPayloadsApiDelegateImpl implements DfPayloadsApiDelegate {
 		try {
 			// ORDS call to delete DF Payload based on notice no
 			responseFromOrds = dfPayloadService.deleteDFPayload(noticeNo, correlationId);
+			
+			PostDFPayloadServiceResponse resp = new PostDFPayloadServiceResponse();
+			resp.setStatusMessage(responseFromOrds.getStatusMessage());
+			return new ResponseEntity<>(resp, HttpStatus.OK);
+			
 		} catch (ApiException e) {
 			String msg = "ERROR deleting DF Payload from ORDS with noticeNo: " + noticeNo + ". Message: " + e.getMessage() + " ORDS Response Status Code: " + e.getCode();
 			e.printStackTrace();
 			logger.error(msg, e);
 			throw new DigitalFormsException(e.getMessage(), e);
-		}
-		
-		if (responseFromOrds == null || StringUtils.isBlank(responseFromOrds.getStatusMessage())) {
-			throw new DigitalFormsException("Invalid PostDFPayloadServiceResponse object");
-		} else if (!"success".equalsIgnoreCase(responseFromOrds.getStatusMessage())) {
-			String msg = "ERROR deleting DF Payload from ORDS with noticeNo: " + noticeNo + ". Message: " + responseFromOrds.getStatusMessage();
-			logger.error(msg, responseFromOrds.getStatusMessage());
-			throw new DigitalFormsException(msg);
-		} else {
-			PostDFPayloadServiceResponse resp = new PostDFPayloadServiceResponse();
-			resp.setStatusMessage(responseFromOrds.getStatusMessage());
-			return new ResponseEntity<>(resp, HttpStatus.OK);
 		}
 	}
 }

--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DFPayloadApiTests.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DFPayloadApiTests.java
@@ -38,14 +38,15 @@ public class DFPayloadApiTests {
 
 	@InjectMocks
 	private DfPayloadsApiDelegateImpl controller;
-	
+
 	private ca.bc.gov.open.pssg.rsbc.digitalforms.ordsclient.api.model.GetDFPayloadServiceResponse goodDFORDSPayloadResponse; 
 
 	private PostDFPayloadServiceRequest goodPOSTRequest;
 	private PutDFPayloadServiceRequest goodPUTRequest;
 	private PostDFPayloadServiceRequest badPOSTRequest;
-	
+
 	Map<String, String> gPayload;
+	private ca.bc.gov.open.pssg.rsbc.digitalforms.ordsclient.api.model.PostDFPayloadServiceResponse responseFromOrds;
 
 	@BeforeEach
 	public void init() {
@@ -84,7 +85,8 @@ public class DFPayloadApiTests {
 		badPOSTRequest.setNoticeTypeCd(DigitalFormsConstants.UNIT_TEST_NOTICE_TYPE);
 
 		badPOSTRequest.setPayload(null); // this is a required field. Leaving it null should result in a 500 and validation error msg.
-
+		
+		responseFromOrds = new ca.bc.gov.open.pssg.rsbc.digitalforms.ordsclient.api.model.PostDFPayloadServiceResponse();
 	}
 
 	@DisplayName("GET, Retrieve Payload success - DFPayload Delegate")
@@ -152,13 +154,16 @@ public class DFPayloadApiTests {
 
 		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
 		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		// Mock underlying DELETE DF Payload response in good case 
+		responseFromOrds.setStatusMessage(DigitalFormsConstants.DIGITALFORMS_SUCCESS_MSG);
+        when(dfPayloadService.deleteDFPayload(any(), any())).thenReturn(responseFromOrds);
 
 		// Create successful DELETE DF Payload and validate response
 		ResponseEntity<PostDFPayloadServiceResponse> controllerResponse = controller
 				.dfpayloadsNoticeNoCorrelationIdDelete(noticeNo, correlationId);
 		PostDFPayloadServiceResponse result = controllerResponse.getBody();
 		Assertions.assertEquals(DigitalFormsConstants.DIGITALFORMS_SUCCESS_MSG, result.getStatusMessage());
-
 	}
 
 	// TODO - need further testing for all possible PUT ORDS response codes and


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- [DF-2224](https://justice.gov.bc.ca/jirarsi/browse/DF-2224?)
- Added functionality to DELETE Digital Forms Payload through calling equivalent ORDS service in DF API. 
- Added success case unit test.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes