### PR TITLE
JUnit tests for all df payload operations

### DIFF
--- a/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DFPayloadApiTests.java
+++ b/digitalforms-api/src/test/java/ca/bc/gov/open/digitalformsapi/viirp/controller/DFPayloadApiTests.java
@@ -12,14 +12,19 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ActiveProfiles;
 
+import ca.bc.gov.open.digitalformsapi.viirp.exception.DigitalFormsException;
+import ca.bc.gov.open.digitalformsapi.viirp.exception.ResourceNotFoundException;
+import ca.bc.gov.open.digitalformsapi.viirp.exception.UnauthorizedException;
 import ca.bc.gov.open.digitalformsapi.viirp.model.GetDFPayloadServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.PostDFPayloadServiceRequest;
 import ca.bc.gov.open.digitalformsapi.viirp.model.PostDFPayloadServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.model.PutDFPayloadServiceRequest;
 import ca.bc.gov.open.digitalformsapi.viirp.utils.DigitalFormsConstants;
+import ca.bc.gov.open.pssg.rsbc.digitalforms.ordsclient.api.handler.ApiException;
 import ca.bc.gov.open.pssg.rsbc.digitalforms.ordsclient.payload.DfPayloadService;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -43,6 +48,12 @@ public class DFPayloadApiTests {
 	private String sPayload; 
 	
 	private ca.bc.gov.open.pssg.rsbc.digitalforms.ordsclient.api.model.PostDFPayloadServiceResponse responseFromOrds;
+	
+	private ApiException unauthorizedApiException;
+	
+	private ApiException notFoundApiException;
+	
+	private ApiException internalServerErrorApiException;
 
 	@BeforeEach
 	public void init() {
@@ -80,6 +91,15 @@ public class DFPayloadApiTests {
 		badPOSTRequest.setPayload(null); // this is a required field. Leaving it null should result in a 500 and validation error msg.
 		
 		responseFromOrds = new ca.bc.gov.open.pssg.rsbc.digitalforms.ordsclient.api.model.PostDFPayloadServiceResponse();
+		
+		// An ApiException which has 401 status code for testing api call responses that are expected to throw unauthorized ApiException
+		unauthorizedApiException = new ApiException(HttpStatus.UNAUTHORIZED.value(), "Unauthorized exception");
+		
+		// An ApiException which has 404 status code for testing api call responses that are expected to throw not found ApiException
+		notFoundApiException = new ApiException(HttpStatus.NOT_FOUND.value(), "Not Found exception");
+		
+		// An ApiException which has 500 status code for testing api call responses that are expected to throw internal server error ApiException
+		internalServerErrorApiException = new ApiException(HttpStatus.INTERNAL_SERVER_ERROR.value(), "Not Found exception");
 	}
 
 	@DisplayName("GET, Retrieve Payload success - DFPayload Delegate")
@@ -101,9 +121,51 @@ public class DFPayloadApiTests {
 		Assertions.assertEquals(true, result.getActive());
 		
 	}
+	
+	@DisplayName("GET, Retrieve Payload, expect 401 Unauthorized - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiGET401Unauthorized() throws Exception {
 
-	// TODO - need further testing for all possible GET ORDS error response codes (401, 404, and 500) 
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.getDFPayload(any(), any())).thenThrow(unauthorizedApiException);
+		
+		// Create GET DF Payload call and ensure UnauthorizedException type of exception is thrown in this case
+		Assertions.assertThrows(UnauthorizedException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdGet(noticeNo, correlationId);
+		});
+	}
+	
+	@DisplayName("GET, Retrieve Payload, expect 404 Not Found - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiGET404NotFound() throws Exception {
 
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.getDFPayload(any(), any())).thenThrow(notFoundApiException);
+		
+		// Create GET DF Payload call and ensure ResourceNotFoundException type of exception is thrown in this case
+		Assertions.assertThrows(ResourceNotFoundException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdGet(noticeNo, correlationId);
+		});
+	}
+	
+	@DisplayName("GET, Retrieve Payload, expect 500 Internal Server Error - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiGET500InternalServerError() throws Exception {
+
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.getDFPayload(any(), any())).thenThrow(internalServerErrorApiException);
+		
+		// Create GET DF Payload call and ensure DigitalFormsException type of exception is thrown in this case
+		Assertions.assertThrows(DigitalFormsException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdGet(noticeNo, correlationId);
+		});
+	}
 	
 	@DisplayName("POST, Create Payload success - DFPayload Delegate")
 	@Test
@@ -121,8 +183,36 @@ public class DFPayloadApiTests {
 		Assertions.assertEquals("Success", result.getStatusMessage());
 
 	}
+	
+	@DisplayName("POST, Create Payload, expect 401 Unauthorized - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiPOST401Unauthorized() throws Exception {
 
-	// TODO - need further testing for all possible POST ORDS error response codes (401, and 500) 
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.postDFPayload(any(), any())).thenThrow(unauthorizedApiException);
+		
+		// Create POST DF Payload call and ensure UnauthorizedException type of exception is thrown in this case
+		Assertions.assertThrows(UnauthorizedException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdPost(noticeNo, correlationId, goodPOSTRequest);
+		});
+	}
+	
+	@DisplayName("POST, Create Payload, expect 500 Internal Server Error - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiPOST500InternalServerError() throws Exception {
+
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.postDFPayload(any(), any())).thenThrow(internalServerErrorApiException);
+		
+		// Create POST DF Payload call and ensure DigitalFormsException type of exception is thrown in this case
+		Assertions.assertThrows(DigitalFormsException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdPost(noticeNo, correlationId, goodPOSTRequest);
+		});
+	}
 
 	@DisplayName("PUT, Update Payload success - DFPayload Delegate")
 	@Test
@@ -133,16 +223,58 @@ public class DFPayloadApiTests {
 		
 		when(dfPayloadService.putDFPayload(any(), any(), any())).thenReturn(goodDFORDSPOSTPayloadResponse);
 
-		// Create successful POST DF Payload call and validate response
+		// Create successful PUT DF Payload call and validate response
 		ResponseEntity<PostDFPayloadServiceResponse> controllerResponse = controller.dfpayloadsNoticeNoCorrelationIdPut(noticeNo, correlationId, goodPUTRequest);
 		PostDFPayloadServiceResponse result = controllerResponse.getBody();
 
 		Assertions.assertEquals("Success", result.getStatusMessage());
 
 	}
-
-	// TODO - need further testing for all possible PUT ORDS error response codes (401, 404, and 500) 
 	
+	@DisplayName("PUT, Update Payload, expect 401 Unauthorized - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiPUT401Unauthorized() throws Exception {
+
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.putDFPayload(any(), any(), any())).thenThrow(unauthorizedApiException);
+		
+		// Create PUT DF Payload call and ensure UnauthorizedException type of exception is thrown in this case
+		Assertions.assertThrows(UnauthorizedException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdPut(noticeNo, correlationId, goodPUTRequest);
+		});
+	}
+	
+	@DisplayName("PUT, Update Payload, expect 404 Not Found - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiPUT404NotFound() throws Exception {
+
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.putDFPayload(any(), any(), any())).thenThrow(notFoundApiException);
+		
+		// Create PUT DF Payload call and ensure ResourceNotFoundException type of exception is thrown in this case
+		Assertions.assertThrows(ResourceNotFoundException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdPut(noticeNo, correlationId, goodPUTRequest);
+		});
+	}
+	
+	@DisplayName("PUT, Update Payload, expect 500 Internal Server Error - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiPUT500InternalServerError() throws Exception {
+
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.putDFPayload(any(), any(), any())).thenThrow(internalServerErrorApiException);
+		
+		// Create PUT DF Payload call and ensure DigitalFormsException type of exception is thrown in this case
+		Assertions.assertThrows(DigitalFormsException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdPut(noticeNo, correlationId, goodPUTRequest);
+		});
+	}
 	
 	@DisplayName("DEL, Remove Payload success - DFPayload Delegate")
 	@Test
@@ -161,7 +293,49 @@ public class DFPayloadApiTests {
 		PostDFPayloadServiceResponse result = controllerResponse.getBody();
 		Assertions.assertEquals(DigitalFormsConstants.DIGITALFORMS_SUCCESS_MSG, result.getStatusMessage());
 	}
-
-	// TODO - need further testing for all possible DELETE ORDS error response codes (401, 404, and 500)
 	
+	@DisplayName("DEL, Remove Payload, expect 401 Unauthorized - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiDELETE401Unauthorized() throws Exception {
+
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.deleteDFPayload(any(), any())).thenThrow(unauthorizedApiException);
+		
+		// Create DELETE DF Payload call and ensure UnauthorizedException type of exception is thrown in this case
+		Assertions.assertThrows(UnauthorizedException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdDelete(noticeNo, correlationId);
+		});
+	}
+	
+	@DisplayName("DEL, Remove Payload, expect 404 Not Found - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiDELETE404NotFound() throws Exception {
+
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.deleteDFPayload(any(), any())).thenThrow(notFoundApiException);
+		
+		// Create DELETE DF Payload call and ensure ResourceNotFoundException type of exception is thrown in this case
+		Assertions.assertThrows(ResourceNotFoundException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdDelete(noticeNo, correlationId);
+		});
+	}
+	
+	@DisplayName("DEL, Remove Payload, expect 500 Internal Server Error - DFPayload Delegate")
+	@Test
+	public void testDFPayloadApiDELETE500InternalServerError() throws Exception {
+
+		String correlationId = DigitalFormsConstants.UNIT_TEST_CORRELATION_ID;
+		String noticeNo = DigitalFormsConstants.UNIT_TEST_NOTICE_NUMBER;
+		
+		when(dfPayloadService.deleteDFPayload(any(), any())).thenThrow(internalServerErrorApiException);
+		
+		// Create DELETE DF Payload call and ensure DigitalFormsException type of exception is thrown in this case
+		Assertions.assertThrows(DigitalFormsException.class, () -> {
+			controller.dfpayloadsNoticeNoCorrelationIdDelete(noticeNo, correlationId);
+		});
+	}
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- Added JUnit tests for all df payload operations for error cases.
- Refactored delete df payload endpoint to throw proper api exceptions.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Ran JUnit tests locally.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes