### PR TITLE
DF-2301 Fix for server does not log HTTP 500 errors from VIPS

### DIFF
--- a/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/controller/CodeTablesApiDelegateImpl.java
+++ b/digitalforms-api/src/main/java/ca/bc/gov/open/digitalformsapi/viirp/controller/CodeTablesApiDelegateImpl.java
@@ -6,8 +6,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClientException;
 
 import ca.bc.gov.open.digitalformsapi.viirp.api.CodetablesApiDelegate;
+import ca.bc.gov.open.digitalformsapi.viirp.exception.DigitalFormsException;
 import ca.bc.gov.open.digitalformsapi.viirp.model.GetCodetablesServiceResponse;
 import ca.bc.gov.open.digitalformsapi.viirp.service.VipsRestService;
 
@@ -24,6 +26,15 @@ public class CodeTablesApiDelegateImpl implements CodetablesApiDelegate{
 		
 		logger.info("Heard a call to the endpoint 'codetablesCorrelationIdGet'");
 		
-		return new ResponseEntity<GetCodetablesServiceResponse>(digitalformsApiService.getCodeTableValues(correlationId), HttpStatus.OK);
+		GetCodetablesServiceResponse _resp = new GetCodetablesServiceResponse();
+		
+		try {
+			_resp = digitalformsApiService.getCodeTableValues(correlationId);
+		} catch (WebClientException e) {
+			logger.error("VIPS Internal Server Error: " + e.getMessage());
+			throw new DigitalFormsException("Internal Server Error at VIPS WS. Failed to get codetables with correlationId : " + correlationId);
+		}
+		
+		return new ResponseEntity<GetCodetablesServiceResponse>(_resp, HttpStatus.OK);
 	}
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- DF-2301
- Fixed the issue with not catching/logging the error when a request is being made to VIPS WS and it returns API related error.
- Added proper exception catch block and logger to capture the error details when VIPS WS responds with an error including 500.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Setup VIPS WS base url to point to a dummy service that returns 500 error as response and confirmed that the error has been caught through the request's catch block and logged into an error log with detailed error message.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes